### PR TITLE
`turbolinks` version bump: `UsersController#create` redirect bugfix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'sass-rails', '5.0.2'
 gem 'uglifier', '2.5.3'
 gem 'coffee-rails', '4.1.0'
 gem 'jquery-rails', '4.0.3'
-gem 'turbolinks', '2.2.0'
+gem 'turbolinks', '2.5.3'
 gem 'jbuilder', '2.2.3'
 gem 'sdoc', '0.4.0', group: :doc
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
-    rdoc (4.2.0)
+    rdoc (4.2.1)
+      json (~> 1.4)
     sass (3.4.20)
     sass-rails (5.0.2)
       railties (>= 4.0.0, < 5.0)
@@ -136,7 +137,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    turbolinks (2.2.0)
+    turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -164,6 +165,9 @@ DEPENDENCIES
   sdoc (= 0.4.0)
   spring (= 1.1.3)
   sqlite3 (= 1.3.9)
-  turbolinks (= 2.2.0)
+  turbolinks (= 2.5.3)
   uglifier (= 2.5.3)
   web-console (= 2.0.0.beta3)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
You were using an old version of turbolinks, which was not compatible with the version of rails you were on. A lot of times when you see a "stack trace" that is not your code, there is a outdated gem version somewhere.
